### PR TITLE
Port to Minecraft 26.2

### DIFF
--- a/Common/src/main/java/com/yungnickyoung/minecraft/betteroceanmonuments/module/StructureProcessorTypeModule.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betteroceanmonuments/module/StructureProcessorTypeModule.java
@@ -3,37 +3,38 @@ package com.yungnickyoung.minecraft.betteroceanmonuments.module;
 import com.yungnickyoung.minecraft.betteroceanmonuments.BetterOceanMonumentsCommon;
 import com.yungnickyoung.minecraft.betteroceanmonuments.world.processor.*;
 import com.yungnickyoung.minecraft.yungsapi.api.autoregister.AutoRegister;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
+import com.mojang.serialization.MapCodec;
+import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
 
 @AutoRegister(BetterOceanMonumentsCommon.MOD_ID)
 public class StructureProcessorTypeModule {
     @AutoRegister("air_processor")
-    public static StructureProcessorType<AirProcessor> AIR_PROCESSOR = () -> AirProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> AIR_PROCESSOR = AirProcessor.CODEC;
 
     @AutoRegister("waterlog_processor")
-    public static StructureProcessorType<WaterlogProcessor> WATERLOG_PROCESSOR = () -> WaterlogProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> WATERLOG_PROCESSOR = WaterlogProcessor.CODEC;
 
     @AutoRegister("random_prismarine_slab_decoration_processor")
-    public static StructureProcessorType<RandomPrismarineSlabDecorationProcessor> RANDOM_PRISMARINE_SLAB_DECORATION_PROCESSOR = () -> RandomPrismarineSlabDecorationProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> RANDOM_PRISMARINE_SLAB_DECORATION_PROCESSOR = RandomPrismarineSlabDecorationProcessor.CODEC;
 
     @AutoRegister("random_dark_prismarine_slab_decoration_processor")
-    public static StructureProcessorType<RandomDarkPrismarineSlabDecorationProcessor> RANDOM_DARK_PRISMARINE_SLAB_DECORATION_PROCESSOR = () -> RandomDarkPrismarineSlabDecorationProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> RANDOM_DARK_PRISMARINE_SLAB_DECORATION_PROCESSOR = RandomDarkPrismarineSlabDecorationProcessor.CODEC;
 
     @AutoRegister("structure_void_processor")
-    public static StructureProcessorType<StructureVoidProcessor> STRUCTURE_VOID_PROCESSOR = () -> StructureVoidProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> STRUCTURE_VOID_PROCESSOR = StructureVoidProcessor.CODEC;
 
     @AutoRegister("sand_gravel_processor")
-    public static StructureProcessorType<SandGravelProcessor> SAND_GRAVEL_PROCESSOR = () -> SandGravelProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> SAND_GRAVEL_PROCESSOR = SandGravelProcessor.CODEC;
 
     @AutoRegister("random_oxidization_processor")
-    public static StructureProcessorType<RandomOxidizationProcessor> RANDOM_OXIDIZATION_PROCESSOR = () -> RandomOxidizationProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> RANDOM_OXIDIZATION_PROCESSOR = RandomOxidizationProcessor.CODEC;
 
     @AutoRegister("seagrass_processor")
-    public static StructureProcessorType<SeagrassProcessor> SEAGRASS_PROCESSOR = () -> SeagrassProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> SEAGRASS_PROCESSOR = SeagrassProcessor.CODEC;
 
     @AutoRegister("random_sponge_processor")
-    public static StructureProcessorType<RandomSpongeProcessor> SPONGE_PROCESSOR = () -> RandomSpongeProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> SPONGE_PROCESSOR = RandomSpongeProcessor.CODEC;
 
     @AutoRegister("leg_processor")
-    public static StructureProcessorType<LegProcessor> LEG_PROCESSOR = () -> LegProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> LEG_PROCESSOR = LegProcessor.CODEC;
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betteroceanmonuments/world/processor/AirProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betteroceanmonuments/world/processor/AirProcessor.java
@@ -8,7 +8,6 @@ import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 
@@ -18,7 +17,7 @@ import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemp
  */
 
 
-public class AirProcessor extends StructureProcessor {
+public class AirProcessor implements StructureProcessor {
     public static final AirProcessor INSTANCE = new AirProcessor();
     public static final MapCodec<AirProcessor> CODEC = MapCodec.unit(() -> INSTANCE);
 
@@ -26,7 +25,7 @@ public class AirProcessor extends StructureProcessor {
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
+                                                             BlockPos templateRelativePos,
                                                              StructureTemplate.StructureBlockInfo blockInfoGlobal,
                                                              StructurePlaceSettings structurePlacementData) {
         if (blockInfoGlobal.state().getBlock() == Blocks.AIR) {
@@ -38,7 +37,7 @@ public class AirProcessor extends StructureProcessor {
         return blockInfoGlobal;
     }
 
-    protected StructureProcessorType<?> getType() {
+    public MapCodec<? extends StructureProcessor> codec() {
         return StructureProcessorTypeModule.AIR_PROCESSOR;
     }
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betteroceanmonuments/world/processor/LegProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betteroceanmonuments/world/processor/LegProcessor.java
@@ -12,7 +12,6 @@ import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 
@@ -22,7 +21,7 @@ import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemp
  */
 
 
-public class LegProcessor extends StructureProcessor {
+public class LegProcessor implements StructureProcessor {
     public static final LegProcessor INSTANCE = new LegProcessor();
     public static final MapCodec<LegProcessor> CODEC = MapCodec.unit(() -> INSTANCE);
 
@@ -30,10 +29,10 @@ public class LegProcessor extends StructureProcessor {
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
+                                                             BlockPos templateRelativePos,
                                                              StructureTemplate.StructureBlockInfo blockInfoGlobal,
                                                              StructurePlaceSettings structurePlacementData) {
-        if (blockInfoGlobal.state().getBlock() == Blocks.BLUE_STAINED_GLASS) {
+        if (blockInfoGlobal.state().getBlock() == Blocks.STAINED_GLASS.blue()) {
             if (levelReader instanceof WorldGenRegion worldGenRegion && !worldGenRegion.getCenter().equals(ChunkPos.containing(blockInfoGlobal.pos()))) {
                 return blockInfoGlobal;
             }
@@ -53,7 +52,7 @@ public class LegProcessor extends StructureProcessor {
         return blockInfoGlobal;
     }
 
-    protected StructureProcessorType<?> getType() {
+    public MapCodec<? extends StructureProcessor> codec() {
         return StructureProcessorTypeModule.LEG_PROCESSOR;
     }
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betteroceanmonuments/world/processor/RandomDarkPrismarineSlabDecorationProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betteroceanmonuments/world/processor/RandomDarkPrismarineSlabDecorationProcessor.java
@@ -12,7 +12,6 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.SlabType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 
@@ -22,7 +21,7 @@ import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemp
  */
 
 
-public class RandomDarkPrismarineSlabDecorationProcessor extends StructureProcessor {
+public class RandomDarkPrismarineSlabDecorationProcessor implements StructureProcessor {
     public static final RandomDarkPrismarineSlabDecorationProcessor INSTANCE = new RandomDarkPrismarineSlabDecorationProcessor();
     public static final MapCodec<RandomDarkPrismarineSlabDecorationProcessor> CODEC = MapCodec.unit(() -> INSTANCE);
 
@@ -30,10 +29,10 @@ public class RandomDarkPrismarineSlabDecorationProcessor extends StructureProces
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
+                                                             BlockPos templateRelativePos,
                                                              StructureTemplate.StructureBlockInfo blockInfoGlobal,
                                                              StructurePlaceSettings structurePlacementData) {
-        if (blockInfoGlobal.state().getBlock() == Blocks.BLUE_CONCRETE) {
+        if (blockInfoGlobal.state().getBlock() == Blocks.CONCRETE.blue()) {
             RandomSource random = structurePlacementData.getRandom(blockInfoGlobal.pos());
             BlockState blockState;
             if (random.nextFloat() < .4f) {
@@ -48,7 +47,7 @@ public class RandomDarkPrismarineSlabDecorationProcessor extends StructureProces
         return blockInfoGlobal;
     }
 
-    protected StructureProcessorType<?> getType() {
+    public MapCodec<? extends StructureProcessor> codec() {
         return StructureProcessorTypeModule.RANDOM_DARK_PRISMARINE_SLAB_DECORATION_PROCESSOR;
     }
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betteroceanmonuments/world/processor/RandomOxidizationProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betteroceanmonuments/world/processor/RandomOxidizationProcessor.java
@@ -10,7 +10,6 @@ import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 
@@ -20,7 +19,7 @@ import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemp
  */
 
 
-public class RandomOxidizationProcessor extends StructureProcessor {
+public class RandomOxidizationProcessor implements StructureProcessor {
     public static final RandomOxidizationProcessor INSTANCE = new RandomOxidizationProcessor();
     public static final MapCodec<RandomOxidizationProcessor> CODEC = MapCodec.unit(() -> INSTANCE);
 
@@ -28,36 +27,36 @@ public class RandomOxidizationProcessor extends StructureProcessor {
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
+                                                             BlockPos templateRelativePos,
                                                              StructureTemplate.StructureBlockInfo blockInfoGlobal,
                                                              StructurePlaceSettings structurePlacementData) {
         RandomSource random = structurePlacementData.getRandom(blockInfoGlobal.pos());
         BlockState blockState;
-        if (blockInfoGlobal.state().getBlock() == Blocks.OXIDIZED_COPPER) {
-            if (random.nextFloat() < 0.1f) blockState = Blocks.EXPOSED_COPPER.defaultBlockState();
-            else if (random.nextFloat() < 0.3f) blockState = Blocks.WEATHERED_COPPER.defaultBlockState();
-            else blockState = Blocks.OXIDIZED_COPPER.defaultBlockState();
+        if (blockInfoGlobal.state().getBlock() == Blocks.COPPER_BLOCK.weathering().oxidized()) {
+            if (random.nextFloat() < 0.1f) blockState = Blocks.COPPER_BLOCK.weathering().exposed().defaultBlockState();
+            else if (random.nextFloat() < 0.3f) blockState = Blocks.COPPER_BLOCK.weathering().weathered().defaultBlockState();
+            else blockState = Blocks.COPPER_BLOCK.weathering().oxidized().defaultBlockState();
             blockInfoGlobal = new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), blockState, blockInfoGlobal.nbt());
-        } else if (blockInfoGlobal.state().getBlock() == Blocks.OXIDIZED_CUT_COPPER) {
-            if (random.nextFloat() < 0.1f) blockState = Blocks.EXPOSED_CUT_COPPER.defaultBlockState();
-            else if (random.nextFloat() < 0.3f) blockState = Blocks.WEATHERED_CUT_COPPER.defaultBlockState();
-            else blockState = Blocks.OXIDIZED_CUT_COPPER.defaultBlockState();
+        } else if (blockInfoGlobal.state().getBlock() == Blocks.CUT_COPPER.weathering().oxidized()) {
+            if (random.nextFloat() < 0.1f) blockState = Blocks.CUT_COPPER.weathering().exposed().defaultBlockState();
+            else if (random.nextFloat() < 0.3f) blockState = Blocks.CUT_COPPER.weathering().weathered().defaultBlockState();
+            else blockState = Blocks.CUT_COPPER.weathering().oxidized().defaultBlockState();
             blockInfoGlobal = new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), blockState, blockInfoGlobal.nbt());
-        } else if (blockInfoGlobal.state().getBlock() == Blocks.OXIDIZED_CUT_COPPER_STAIRS) {
-            if (random.nextFloat() < 0.1f) blockState = Blocks.EXPOSED_CUT_COPPER_STAIRS.withPropertiesOf(blockInfoGlobal.state());
-            else if (random.nextFloat() < 0.3f) blockState = Blocks.WEATHERED_CUT_COPPER_STAIRS.withPropertiesOf(blockInfoGlobal.state());
-            else blockState = Blocks.OXIDIZED_CUT_COPPER_STAIRS.withPropertiesOf(blockInfoGlobal.state());
+        } else if (blockInfoGlobal.state().getBlock() == Blocks.CUT_COPPER_STAIRS.weathering().oxidized()) {
+            if (random.nextFloat() < 0.1f) blockState = Blocks.CUT_COPPER_STAIRS.weathering().exposed().withPropertiesOf(blockInfoGlobal.state());
+            else if (random.nextFloat() < 0.3f) blockState = Blocks.CUT_COPPER_STAIRS.weathering().weathered().withPropertiesOf(blockInfoGlobal.state());
+            else blockState = Blocks.CUT_COPPER_STAIRS.weathering().oxidized().withPropertiesOf(blockInfoGlobal.state());
             blockInfoGlobal = new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), blockState, blockInfoGlobal.nbt());
-        } else if (blockInfoGlobal.state().getBlock() == Blocks.OXIDIZED_CUT_COPPER_SLAB) {
-            if (random.nextFloat() < 0.1f) blockState = Blocks.EXPOSED_CUT_COPPER_SLAB.withPropertiesOf(blockInfoGlobal.state());
-            else if (random.nextFloat() < 0.3f) blockState = Blocks.WEATHERED_CUT_COPPER_SLAB.withPropertiesOf(blockInfoGlobal.state());
-            else blockState = Blocks.OXIDIZED_CUT_COPPER_SLAB.withPropertiesOf(blockInfoGlobal.state());
+        } else if (blockInfoGlobal.state().getBlock() == Blocks.CUT_COPPER_SLAB.weathering().oxidized()) {
+            if (random.nextFloat() < 0.1f) blockState = Blocks.CUT_COPPER_SLAB.weathering().exposed().withPropertiesOf(blockInfoGlobal.state());
+            else if (random.nextFloat() < 0.3f) blockState = Blocks.CUT_COPPER_SLAB.weathering().weathered().withPropertiesOf(blockInfoGlobal.state());
+            else blockState = Blocks.CUT_COPPER_SLAB.weathering().oxidized().withPropertiesOf(blockInfoGlobal.state());
             blockInfoGlobal = new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), blockState, blockInfoGlobal.nbt());
         }
         return blockInfoGlobal;
     }
 
-    protected StructureProcessorType<?> getType() {
+    public MapCodec<? extends StructureProcessor> codec() {
         return StructureProcessorTypeModule.RANDOM_OXIDIZATION_PROCESSOR;
     }
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betteroceanmonuments/world/processor/RandomPrismarineSlabDecorationProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betteroceanmonuments/world/processor/RandomPrismarineSlabDecorationProcessor.java
@@ -12,7 +12,6 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.SlabType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 
@@ -22,7 +21,7 @@ import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemp
  */
 
 
-public class RandomPrismarineSlabDecorationProcessor extends StructureProcessor {
+public class RandomPrismarineSlabDecorationProcessor implements StructureProcessor {
     public static final RandomPrismarineSlabDecorationProcessor INSTANCE = new RandomPrismarineSlabDecorationProcessor();
     public static final MapCodec<RandomPrismarineSlabDecorationProcessor> CODEC = MapCodec.unit(() -> INSTANCE);
 
@@ -30,10 +29,10 @@ public class RandomPrismarineSlabDecorationProcessor extends StructureProcessor 
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
+                                                             BlockPos templateRelativePos,
                                                              StructureTemplate.StructureBlockInfo blockInfoGlobal,
                                                              StructurePlaceSettings structurePlacementData) {
-        if (blockInfoGlobal.state().getBlock() == Blocks.LIME_CONCRETE) {
+        if (blockInfoGlobal.state().getBlock() == Blocks.CONCRETE.lime()) {
             RandomSource random = structurePlacementData.getRandom(blockInfoGlobal.pos());
             BlockState blockState;
             if (random.nextFloat() < .4f) {
@@ -48,7 +47,7 @@ public class RandomPrismarineSlabDecorationProcessor extends StructureProcessor 
         return blockInfoGlobal;
     }
 
-    protected StructureProcessorType<?> getType() {
+    public MapCodec<? extends StructureProcessor> codec() {
         return StructureProcessorTypeModule.RANDOM_PRISMARINE_SLAB_DECORATION_PROCESSOR;
     }
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betteroceanmonuments/world/processor/RandomSpongeProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betteroceanmonuments/world/processor/RandomSpongeProcessor.java
@@ -9,7 +9,6 @@ import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 
@@ -19,7 +18,7 @@ import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemp
  */
 
 
-public class RandomSpongeProcessor extends StructureProcessor implements ISafeWorldModifier {
+public class RandomSpongeProcessor implements StructureProcessor, ISafeWorldModifier {
     public static final RandomSpongeProcessor INSTANCE = new RandomSpongeProcessor();
     public static final MapCodec<RandomSpongeProcessor> CODEC = MapCodec.unit(() -> INSTANCE);
 
@@ -27,10 +26,10 @@ public class RandomSpongeProcessor extends StructureProcessor implements ISafeWo
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
+                                                             BlockPos templateRelativePos,
                                                              StructureTemplate.StructureBlockInfo blockInfoGlobal,
                                                              StructurePlaceSettings structurePlacementData) {
-        if (blockInfoGlobal.state().is(Blocks.ORANGE_STAINED_GLASS)) {
+        if (blockInfoGlobal.state().is(Blocks.STAINED_GLASS.orange())) {
             if (structurePlacementData.getRandom(blockInfoGlobal.pos()).nextFloat() < 0.75f) {
                 return new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), Blocks.WET_SPONGE.defaultBlockState(), null);
             } else {
@@ -41,7 +40,7 @@ public class RandomSpongeProcessor extends StructureProcessor implements ISafeWo
         return blockInfoGlobal;
     }
 
-    protected StructureProcessorType<?> getType() {
+    public MapCodec<? extends StructureProcessor> codec() {
         return StructureProcessorTypeModule.SPONGE_PROCESSOR;
     }
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betteroceanmonuments/world/processor/SandGravelProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betteroceanmonuments/world/processor/SandGravelProcessor.java
@@ -8,7 +8,6 @@ import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 
@@ -18,7 +17,7 @@ import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemp
  */
 
 
-public class SandGravelProcessor extends StructureProcessor {
+public class SandGravelProcessor implements StructureProcessor {
     public static final SandGravelProcessor INSTANCE = new SandGravelProcessor();
     public static final MapCodec<SandGravelProcessor> CODEC = MapCodec.unit(() -> INSTANCE);
 
@@ -26,16 +25,16 @@ public class SandGravelProcessor extends StructureProcessor {
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
+                                                             BlockPos templateRelativePos,
                                                              StructureTemplate.StructureBlockInfo blockInfoGlobal,
                                                              StructurePlaceSettings structurePlacementData) {
-        if (blockInfoGlobal.state().getBlock() == Blocks.YELLOW_STAINED_GLASS) {
+        if (blockInfoGlobal.state().getBlock() == Blocks.STAINED_GLASS.yellow()) {
             blockInfoGlobal = new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), Blocks.GRAVEL.defaultBlockState(), blockInfoGlobal.nbt());
         }
         return blockInfoGlobal;
     }
 
-    protected StructureProcessorType<?> getType() {
+    public MapCodec<? extends StructureProcessor> codec() {
         return StructureProcessorTypeModule.SAND_GRAVEL_PROCESSOR;
     }
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betteroceanmonuments/world/processor/SeagrassProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betteroceanmonuments/world/processor/SeagrassProcessor.java
@@ -11,7 +11,6 @@ import net.minecraft.world.level.block.TallSeagrassBlock;
 import net.minecraft.world.level.block.state.properties.DoubleBlockHalf;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 
@@ -21,7 +20,7 @@ import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemp
  */
 
 
-public class SeagrassProcessor extends StructureProcessor implements ISafeWorldModifier {
+public class SeagrassProcessor implements StructureProcessor, ISafeWorldModifier {
     public static final SeagrassProcessor INSTANCE = new SeagrassProcessor();
     public static final MapCodec<SeagrassProcessor> CODEC = MapCodec.unit(() -> INSTANCE);
 
@@ -29,7 +28,7 @@ public class SeagrassProcessor extends StructureProcessor implements ISafeWorldM
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
+                                                             BlockPos templateRelativePos,
                                                              StructureTemplate.StructureBlockInfo blockInfoGlobal,
                                                              StructurePlaceSettings structurePlacementData) {
         if (blockInfoGlobal.state().is(Blocks.RED_SANDSTONE_SLAB)) {
@@ -45,7 +44,7 @@ public class SeagrassProcessor extends StructureProcessor implements ISafeWorldM
         return blockInfoGlobal;
     }
 
-    protected StructureProcessorType<?> getType() {
+    public MapCodec<? extends StructureProcessor> codec() {
         return StructureProcessorTypeModule.SEAGRASS_PROCESSOR;
     }
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betteroceanmonuments/world/processor/StructureVoidProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betteroceanmonuments/world/processor/StructureVoidProcessor.java
@@ -8,7 +8,6 @@ import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 
@@ -20,7 +19,7 @@ import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemp
  */
 
 
-public class StructureVoidProcessor extends StructureProcessor {
+public class StructureVoidProcessor implements StructureProcessor {
     public static final StructureVoidProcessor INSTANCE = new StructureVoidProcessor();
     public static final MapCodec<StructureVoidProcessor> CODEC = MapCodec.unit(() -> INSTANCE);
 
@@ -28,16 +27,16 @@ public class StructureVoidProcessor extends StructureProcessor {
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
+                                                             BlockPos templateRelativePos,
                                                              StructureTemplate.StructureBlockInfo blockInfoGlobal,
                                                              StructurePlaceSettings structurePlacementData) {
-        if (blockInfoGlobal.state().is(Blocks.PURPUR_SLAB) || blockInfoGlobal.state().is(Blocks.BROWN_WOOL)) {
+        if (blockInfoGlobal.state().is(Blocks.PURPUR_SLAB) || blockInfoGlobal.state().is(Blocks.WOOL.brown())) {
             blockInfoGlobal = new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), levelReader.getBlockState(blockInfoGlobal.pos()), blockInfoGlobal.nbt());
         }
         return blockInfoGlobal;
     }
 
-    protected StructureProcessorType<?> getType() {
+    public MapCodec<? extends StructureProcessor> codec() {
         return StructureProcessorTypeModule.STRUCTURE_VOID_PROCESSOR;
     }
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betteroceanmonuments/world/processor/WaterlogProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betteroceanmonuments/world/processor/WaterlogProcessor.java
@@ -10,7 +10,6 @@ import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 
@@ -20,7 +19,7 @@ import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemp
  */
 
 
-public class WaterlogProcessor extends StructureProcessor {
+public class WaterlogProcessor implements StructureProcessor {
     public static final WaterlogProcessor INSTANCE = new WaterlogProcessor();
     public static final MapCodec<WaterlogProcessor> CODEC = MapCodec.unit(() -> INSTANCE);
 
@@ -28,14 +27,14 @@ public class WaterlogProcessor extends StructureProcessor {
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
+                                                             BlockPos templateRelativePos,
                                                              StructureTemplate.StructureBlockInfo blockInfoGlobal,
                                                              StructurePlaceSettings structurePlacementData) {
         // Schedule fluid ticks for water blocks along chunk boundaries
         if (blockInfoGlobal.state().liquid() && blockInfoGlobal.pos().getY() < levelReader.getSeaLevel()) {
             if (levelReader instanceof WorldGenRegion worldGenRegion && worldGenRegion.getCenter().equals(ChunkPos.containing(blockInfoGlobal.pos()))) {
                 if (blockInfoGlobal.pos().getX() % 16 == 0 || blockInfoGlobal.pos().getX() % 16 == 15 || blockInfoGlobal.pos().getZ() % 16 == 0 || blockInfoGlobal.pos().getZ() % 16 == 15) {
-                    levelReader.getChunk(blockInfoGlobal.pos()).markPosForPostprocessing(blockInfoGlobal.pos());
+                    levelReader.getChunk(blockInfoGlobal.pos()).markPosForPostProcessing(blockInfoGlobal.pos());
                 }
             }
         }
@@ -50,7 +49,7 @@ public class WaterlogProcessor extends StructureProcessor {
         return blockInfoGlobal;
     }
 
-    protected StructureProcessorType<?> getType() {
+    public MapCodec<? extends StructureProcessor> codec() {
         return StructureProcessorTypeModule.WATERLOG_PROCESSOR;
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,16 +11,16 @@ mod_description=A complete redesign of Minecraft's ocean monuments!
 mod_credits=Thanks so much to all my patrons!
 license=LGPLv3
 maven_group=com.yungnickyoung.minecraft.betteroceanmonuments
-mc_version=26.1.2
-mc_version_range=[26.1,)
-mc_version_range_fabric=>=26.1
+mc_version=26.2
+mc_version_range=[26.2,)
+mc_version_range_fabric=>=26.2
 ## This is the version of minecraft that the 'common' project uses, you can find a list of all versions here
 ## https://projects.neoforged.net/neoforged/neoform
-mc_version_neo_form=26.1.2-1
+mc_version_neo_form=26.2-2
 
 # CurseForge/Modrinth Publishing
 cursegradle_version=1.1.24
-compatible_versions=26.1.1,26.1.2
+compatible_versions=26.2
 curseforge_project_id_fabric=689252
 curseforge_project_id_neoforge=689238
 modrinth_project_id=3dT9sgt4
@@ -30,14 +30,14 @@ debug_publish=true
 yungsapi_version=6.1.0
 
 # Fabric
-fabric_version=0.150.0
-fabric_loader_version=0.18.6
-clothconfig_version_fabric=26.1.154
-modmenu_version_fabric=18.0.0-beta.1
+fabric_version=0.154.2
+fabric_loader_version=0.19.3
+clothconfig_version_fabric=26.2.155
+modmenu_version_fabric=20.0.1
 
 # NeoForge
-neoforge_version=26.1.2.75
-neoforge_version_range=[26.1.2.75,)
+neoforge_version=26.2.0.41-beta
+neoforge_version_range=[26.2.0.41-beta,)
 neoforge_loader_version_range=[4,)
 
 # Credentials for publishing. Gets overwritten with global gradle.properties.


### PR DESCRIPTION
## Summary

- update the Minecraft, Fabric, Fabric API, Cloth Config, Mod Menu, NeoForm, and NeoForge targets for Minecraft 26.2
- migrate the Minecraft 26.2 APIs and data formats used by this project
- keep the Common, Fabric, and NeoForge modules aligned with the YUNG's API 26.2 port

Depends on YUNG-GANG/YUNGs-API#109.

## Validation

- `gradlew build --no-daemon --console=plain` passes for Common, Fabric, and NeoForge on Java 25
- Fabric client and server startup were validated in a Minecraft 26.2 PrismLauncher instance
- the build was tested against the Common, Fabric, and NeoForge artifacts from the YUNG's API 26.2 port

The existing LGPL-3.0 license is preserved.
